### PR TITLE
Discussion PR: propose [temporary] removal of LiveView for eventual consistency

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -3,7 +3,7 @@
 We are `@NFIBrokerage`, a team of developers working at [NFI Industries][nfi]. We're building a Transportation Management System (TMS) with
 
 - ⚗️  Elixir
-- 🔥 Phoenix and LiveView
+- 🔥 Phoenix
 - ♻️  Event Sourcing, CQRS, and DDD
 
 Check out some of our [open source libraries][nfibrokerage]!


### PR DESCRIPTION
Disclaimer: I'm reading and working through the LiveView book for the first time

Asking if people think hands should be stayed here.   To my taste, this makes sense to 🔪 because it sets expectations with new entrants and outside parties.  When I saw it, felt disingenuous.

In no way precludes adding it back at a different time, or someone veto-ing.  Can imagine arguments like, "well, we use it in soooome places..." which is defy a valid take, but not normative to my 👂. 
